### PR TITLE
Add separate uWSGI Docker Image for use by the antivirus api

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: "Run our tests"
+
+on:
+  pull_request:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    env:
+      BASE_HTTP_BUILDSTATIC_IMAGE_NAME: dmp-http-static
+      BASE_HTTP_FRONTEND_IMAGE_NAME: dmp-http-frontend
+      BASE_HTTP_HEADLESS_IMAGE_NAME: dmp-http-headless
+      BASE_WSGI_IMAGE_NAME: dmp-wsgi
+      BASE_WSGI_ANTIVIRUS_IMAGE_NAME: dmp-wsgi-ativirus
+      BUILD_VERSION: test
+
+    steps:
+      -
+        name: Checkout code
+        uses: actions/checkout@v4
+
+      -
+        name: Build images
+        run: make build

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ build:
 	$(if ${BASE_HTTP_FRONTEND_IMAGE_NAME},,$(error Must specify BASE_HTTP_FRONTEND_IMAGE_NAME))
 	$(if ${BASE_HTTP_HEADLESS_IMAGE_NAME},,$(error Must specify BASE_HTTP_HEADLESS_IMAGE_NAME))
 	$(if ${BASE_WSGI_IMAGE_NAME},,$(error Must specify BASE_WSGI_IMAGE_NAME))
+	$(if ${BASE_WSGI_ANTIVIRUS_IMAGE_NAME},,$(error Must specify BASE_WSGI_ANTIVIRUS_IMAGE_NAME))
+
 	$(eval BUILD_DATE := $(shell date -u '+%Y%m%dT%H%M%SZ'))
 	$(eval BUILD_ARGS := --build-arg BUILD_DATE=${BUILD_DATE} --build-arg BUILD_VERSION=${BUILD_VERSION})
 
@@ -21,3 +23,6 @@ build:
 
 	docker build ${BUILD_ARGS} -t ${BASE_WSGI_IMAGE_NAME} wsgi
 	docker tag ${BASE_WSGI_IMAGE_NAME} ${BASE_WSGI_IMAGE_NAME}:${BUILD_VERSION}
+
+	docker build ${BUILD_ARGS} -t ${BASE_WSGI_ANTIVIRUS_IMAGE_NAME} -f wsgi/Dockerfile.antivirus wsgi
+	docker tag ${BASE_WSGI_ANTIVIRUS_IMAGE_NAME} ${BASE_WSGI_ANTIVIRUS_IMAGE_NAME}:${BUILD_VERSION}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@ The previous architecture of "supervisord + nginx + uwsgi in socket mode + awslo
 There are fours types of Docker base image created by this repo:
 
 * _wsgi_ - uWSGI running in httpsocket mode, delivering the app backend
+* _wsgi-antivirus_ - uWSGI running in httpsocket mode, delivering the antivirus api backend (see [Why the Antivirus API uses a different uWSGI image](#why-the-antivirus-api-uses-a-different-uwgsi-image))
 * _http-headless_ - Nginx server acting as reverse proxy to _wsgi_ container 
 * _http-frontend_ - Nginx server acting as reverse proxy to _wsgi_ container and providing direct service of static files from the app
 * _http-buildstatic_ - This is a Node-based image which is used temporarily to build the static assets for frontend sites
+
+## Why the Antivirus API uses a different uWSGI image
+
+There is a recently-discovered bug (Oct 2023) in the libcrypto package (source [Python Connector fails to connect with 'LibraryNotFoundError: Error detecting the version of libcrypto'](https://community.snowflake.com/s/article/Python-Connector-fails-to-connect-with-LibraryNotFoundError-Error-detecting-the-version-of-libcrypto)):
+
+> The issue occurs due to a combination of the following conditions involving dependencies of the Snowflake Python Connector:
+> - Use of OpenSSL 3.0.10 or later 3.0.x (with x >= 10), and
+> - Use of Python PyPI package oscrypto version 1.3.0 or earlier
+>
+> Specifically, an issue in oscrypto 1.3.0 and earlier releases causes it to fail when encountering OpenSSL release versions with a multi-digit patch level version (such as the '10' in '3.0.10').
+
+There is a discussion around this issue on [GitHub](https://github.com/wbond/oscrypto/issues/78) however, a new release does not seem to be forthcoming.
+
+As such, for now, we will use a base image with an older version of debian `python:3.9-slim-buster`, instead of `python:3.9-slim-bookworm` which we use for all the other apps.

--- a/wsgi/Dockerfile.antivirus
+++ b/wsgi/Dockerfile.antivirus
@@ -1,0 +1,30 @@
+# Python pinned as per original project
+FROM python:3.9-slim-buster
+
+ENV APP_DIR=/app
+ENV DEP_PYUWSGI_VERSION=2.0.22
+
+ARG BUILD_DATE
+ARG BUILD_VERSION
+LABEL BUILD_DATE=${BUILD_DATE}
+LABEL BUILD_VERSION=${BUILD_VERSION}
+
+WORKDIR ${APP_DIR}
+RUN /usr/sbin/groupadd -r uwsgi && \
+    /usr/sbin/useradd --no-log-init -r -g uwsgi uwsgi && \
+    /usr/local/bin/python3 -m venv venv && \
+    /app/venv/bin/pip3 install --no-cache-dir --upgrade pip && \
+    /app/venv/bin/pip3 install --no-cache-dir pyuwsgi==${DEP_PYUWSGI_VERSION}
+
+CMD ["/app/venv/bin/uwsgi", "--http-socket", ":8888", "--master", "-w", "application:application"]
+EXPOSE 8888
+
+ONBUILD ARG release_name
+ONBUILD COPY requirements.txt ${APP_DIR}
+ONBUILD RUN echo ${release_name} > ${APP_DIR}/version_label && \
+            apt-get update && \
+            apt-get install -y curl gcc git libffi-dev && \
+            /app/venv/bin/pip3 install --no-cache-dir --upgrade pip && \
+            /app/venv/bin/pip3 install --no-cache-dir -r requirements.txt
+ONBUILD COPY --chown=uwsgi:uwsgi . ${APP_DIR}
+ONBUILD USER uwsgi


### PR DESCRIPTION
I have added a new uWSGI Docker image for use by the antivirus api. This image uses an older version of debian as the base of the image to get round the `oscrypto` version issue.

In addition I’ve added some GitHub actions to check that the images can build and dependabot config to get any dependency updates.