### PR TITLE
Add AWS CLI tools to the WSGI containers

### DIFF
--- a/wsgi/Dockerfile
+++ b/wsgi/Dockerfile
@@ -22,7 +22,7 @@ EXPOSE 8888
 ONBUILD ARG release_name
 ONBUILD COPY requirements.txt ${APP_DIR}
 ONBUILD RUN echo ${release_name} > ${APP_DIR}/version_label && \
-            apk upgrade && apk add build-base curl git libffi libffi-dev && rm -rf /var/cache/apk && \
+            apk upgrade && apk add aws-cli build-base curl git libffi libffi-dev && rm -rf /var/cache/apk && \
             /app/venv/bin/pip3 install --no-cache-dir --upgrade pip -r requirements.txt && \
             apk del build-base libffi-dev && rm -rf /root/.cache
 ONBUILD COPY --chown=uwsgi:uwsgi . ${APP_DIR}


### PR DESCRIPTION
We need to use shell-based AWS tools for URL signing because botocore is not playing by the rules when it comes to regional bucket domain names.

See: https://crowncommercialservice.atlassian.net/browse/GMTRP-137