### PR TITLE
Enable support for ECS service discovery

### DIFF
--- a/http/Dockerfile.frontend
+++ b/http/Dockerfile.frontend
@@ -16,3 +16,5 @@ EXPOSE 8080
 
 ONBUILD ARG DM_APP_NAME
 ONBUILD RUN sed -i "s/{DM_APP_NAME}/${DM_APP_NAME}/g" /etc/nginx/nginx.conf
+ONBUILD ARG DM_BACKEND=localhost:8888
+ONBUILD RUN sed -i "s/{DM_BACKEND}/${DM_BACKEND}/g" /etc/nginx/sites-enabled/app.conf

--- a/http/Dockerfile.headless
+++ b/http/Dockerfile.headless
@@ -14,3 +14,5 @@ EXPOSE 8080
 
 ONBUILD ARG DM_APP_NAME
 ONBUILD RUN sed -i "s/{DM_APP_NAME}/${DM_APP_NAME}/g" /etc/nginx/nginx.conf
+ONBUILD ARG DM_BACKEND=localhost:8888
+ONBUILD RUN sed -i "s/{DM_BACKEND}/${DM_BACKEND}/g" /etc/nginx/sites-enabled/app.conf

--- a/http/app-frontend.conf
+++ b/http/app-frontend.conf
@@ -13,7 +13,6 @@ server {
     location / {
         # Make login 'next' redirects reference the original HOST
         proxy_set_header Host $host;
-        # ECS Fargate - Task containers communicate on localhost address
-        proxy_pass http://127.0.0.1:8888;
+        proxy_pass http://{DM_BACKEND};
     }
 }

--- a/http/app-headless.conf
+++ b/http/app-headless.conf
@@ -3,6 +3,6 @@ server {
 
     location / {
         # ECS Fargate - Task containers communicate on localhost address
-       proxy_pass http://127.0.0.1:8888;
+        proxy_pass http://{DM_BACKEND};
     }
 }


### PR DESCRIPTION
This PR adds a container build argument to enable configuration of the backend, rather than having it hardcoded to `localhost:8888`. The original value remains as a default which can be overridden during build of the application images. 

Before this can be merged, I want to validate whether ECS service discovery uses `http` or `https`. 