### PR TITLE
Add entrypoint script to handle runtime env vars

### DIFF
--- a/http/Dockerfile.frontend
+++ b/http/Dockerfile.frontend
@@ -11,10 +11,6 @@ COPY nginx.conf /etc/nginx/nginx.conf
 RUN rm -f /etc/nginx/conf.d/*.conf
 COPY --chown=nginx:nginx sites-enabled.conf /etc/nginx/conf.d/sites-enabled.conf
 COPY --chown=nginx:nginx app-frontend.conf /etc/nginx/sites-enabled/app.conf
+COPY configure-nginx.sh /docker-entrypoint.d/10-configure-nginx.sh
 
 EXPOSE 8080
-
-ONBUILD ARG DM_APP_NAME
-ONBUILD RUN sed -i "s/{DM_APP_NAME}/${DM_APP_NAME}/g" /etc/nginx/nginx.conf
-ONBUILD ARG DM_BACKEND=localhost:8888
-ONBUILD RUN sed -i "s/{DM_BACKEND}/${DM_BACKEND}/g" /etc/nginx/sites-enabled/app.conf

--- a/http/Dockerfile.headless
+++ b/http/Dockerfile.headless
@@ -9,10 +9,6 @@ COPY nginx.conf /etc/nginx/nginx.conf
 RUN rm -f /etc/nginx/conf.d/*.conf
 COPY --chown=nginx:nginx sites-enabled.conf /etc/nginx/conf.d/sites-enabled.conf
 COPY --chown=nginx:nginx app-headless.conf /etc/nginx/sites-enabled/app.conf
+COPY configure-nginx.sh /docker-entrypoint.d/10-configure-nginx.sh
 
 EXPOSE 8080
-
-ONBUILD ARG DM_APP_NAME
-ONBUILD RUN sed -i "s/{DM_APP_NAME}/${DM_APP_NAME}/g" /etc/nginx/nginx.conf
-ONBUILD ARG DM_BACKEND=localhost:8888
-ONBUILD RUN sed -i "s/{DM_BACKEND}/${DM_BACKEND}/g" /etc/nginx/sites-enabled/app.conf

--- a/http/configure-nginx.sh
+++ b/http/configure-nginx.sh
@@ -1,0 +1,8 @@
+# Set default value for DM_BACKEND if not provided
+if [ -z "$DM_BACKEND" ]; then
+  DM_BACKEND="localhost:8888"
+fi
+
+# Replace placeholders in nginx configuration files with the values from environment variables
+sed -i "s/{DM_APP_NAME}/${DM_APP_NAME}/g" /etc/nginx/nginx.conf
+sed -i "s/{DM_BACKEND}/${DM_BACKEND}/g" /etc/nginx/sites-enabled/app.conf


### PR DESCRIPTION
* Handles environment variables specified in ECS tasks and replaces placeholders in the nginx configuration files. 
* Adds `DM_BACKEND` which is a requirement for using ECS service discovery with hostnames declared in the env vars. 
* Includes a default value for the backend hostname to ensure backwards compatibility with the current architecture.
* Fixes a design bug around the implementation of `DM_APP_NAME`, which has never worked, resulting in the app name being empty in the http container logs. 