### PR TITLE
Add a change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Digital Marketplace base Docker image
+
+Records breaking changes from major version bumps
+
+## 1.0.0
+
+Initial version.
+
+Creates the images using:
+- Python 3.9
+- Node 20.9


### PR DESCRIPTION
Now that things are settled I want the apps to use specific version of the Docker builds instead of using the latest. this is because we may introduce a breaking change in our Docker build (e.g. change the Python version) but we will still want to be able to build the apps without the change.